### PR TITLE
Feat:Exam duplications on upload

### DIFF
--- a/genaigrader/services/exam_service.py
+++ b/genaigrader/services/exam_service.py
@@ -2,9 +2,14 @@ from typing import List, Dict
 from ..models import Exam
 import re
 
-def create_exam(uploaded_file, course, user, request):
+
+def resolve_exam_name(uploaded_file, request):
+    """Resolve exam name using user input first, falling back to uploaded file name."""
     exam_name = request.POST.get("user_exam", "").strip()
-    description = exam_name if exam_name else uploaded_file.name
+    return exam_name if exam_name else uploaded_file.name
+
+def create_exam(uploaded_file, course, user, request):
+    description = resolve_exam_name(uploaded_file, request)
     return Exam(
         description=description,
         course=course,

--- a/genaigrader/services/upload_file_service.py
+++ b/genaigrader/services/upload_file_service.py
@@ -1,13 +1,12 @@
-from django.http import StreamingHttpResponse, HttpResponse
+from django.http import StreamingHttpResponse, HttpResponse, JsonResponse
 from django.db import transaction
-from genaigrader.models import Question, QuestionOption
+from genaigrader.models import Question, QuestionOption, Exam
 from genaigrader.services.file_service import save_uploaded_file
-from genaigrader.services.exam_service import process_exam_file, create_exam
+from genaigrader.services.exam_service import process_exam_file, create_exam, resolve_exam_name
 from genaigrader.services.course_service import get_or_create_course
 from genaigrader.services.model_service import get_or_create_model
 from genaigrader.services.stream_service import stream_responses
 from genaigrader.llm_api import LlmApi
-
 
 def validate_model(request):
     """Retrieve and validate LLM model from the request."""
@@ -66,24 +65,38 @@ def handle_file_upload(request):
     """Main entrypoint to process an upload_file view POST request."""
     if request.method != 'POST':
         return HttpResponse("Method not allowed", status=405)
-
     try:
         # Step 1: initial validations
         course = get_or_create_course(request)
         uploaded_file = request.FILES['file']
+        user = request.user
 
         # Step 2: model validation
         llm = validate_model(request)
 
-        # Step 3: file parsing and validation
+        # Step 3: block if exam name already exists in this course
+        existing_exam = find_exam_name_conflict(uploaded_file, course, user, request)
+        if existing_exam:
+            return JsonResponse(
+                {
+                    "error": "duplicate_exam",
+                    "existing_exam_id": existing_exam.id,
+                    "exam_name": existing_exam.description,
+                    "course_name": existing_exam.course.name,
+                    "message": "An exam with this name already exists in this course.",
+                },
+                status=409,
+            )
+
+        # Step 4: file parsing and validation
         questions_data = parse_and_validate_file(uploaded_file)
 
-        # Step 4: persist to DB
+        # Step 5: persist to DB
         exam = persist_exam_and_questions(
             uploaded_file, course, request.user, request, questions_data
         )
 
-        # Step 5: stream LLM response
+        # Step 6: stream LLM response
         user_prompt = request.POST.get('user_prompt', '')
         notes = request.POST.get('notes', '')
         stream = stream_responses(
@@ -98,3 +111,15 @@ def handle_file_upload(request):
 
     except Exception as e:
         return HttpResponse(f"Error: {str(e)}", status=400)
+
+
+def find_exam_name_conflict(uploaded_file, course, user, request):
+    """Return an existing Exam when the resolved name already exists in the same course, else None."""
+    exam_name = resolve_exam_name(uploaded_file, request)
+    return Exam.objects.select_related('course').filter(
+        description__iexact=exam_name,
+        course=course,
+        user=user
+    ).first()
+
+

--- a/genaigrader/templates/evaluate.html
+++ b/genaigrader/templates/evaluate.html
@@ -12,7 +12,6 @@
 {% block content %}
   <h2>Exams</h2>
   <form id="exam-form">
-    <!-- Course selection -->
     <div id="course-selection">
       <div>
         <input type="radio" name="course_choice" id="existing-course" value="existing" checked>
@@ -26,18 +25,17 @@
       <div>
         <input type="radio" name="course_choice" id="new-course-radio" value="new">
         <label for="new-course-radio">New course:</label>
-        <input type="text" id="new-course-input" name="new_course" placeholder="Name of new course" style="display: none;">
+        <input type="text" id="new-course-input" name="new_course" placeholder="Name of new course" class="is-hidden">
       </div>
     </div>
 
     {% include "partials/model_select.html" %}
 
-    <!-- File upload -->
     <input type="file" name="file" accept=".txt" required />
 
-    <!-- Optional fields -->
     <textarea id="user-prompt" name="user_prompt" placeholder="Write your prompt... (optional)" class="eval-user-prompt-fullwidth" rows="3"></textarea>
-    <input type="text" id="user-exam" name="user_exam" placeholder="Exam name (optional)..."/>
+    <input type="text" id="user-exam" name="user_exam" placeholder="Exam name (optional)..." aria-describedby="user-exam-error"/>
+    <div id="user-exam-error" class="field-error" role="alert" aria-live="polite"></div>
     <textarea id="notes" name="notes" placeholder="Notes for this evaluation... (e.g., exam difficulty, hardware used)" class="eval-user-prompt-fullwidth" rows="2"></textarea>
 
     <button type="submit">Upload File</button>

--- a/genaigrader/tests/tests_exam_files.py
+++ b/genaigrader/tests/tests_exam_files.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase
 
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -51,21 +53,25 @@ class UploadFileTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = self._create_user()
+        self.course = Course.objects.create(name="Test Course", user=self.user)
 
     def _create_user(self):
         return User.objects.create_user(username="testuser", password="password")
 
-    def _mock_request(self, file_content):
+    def _mock_request(self, file_content, file_name="test.txt", **extra_post_data):
         """Create a mock request with the necessary parameters."""
+        post_data = {
+            "course_choice": "existing",
+            "course_id": str(self.course.id),
+            "model": "Test Model",
+        }
+        post_data.update(extra_post_data)
+
         request = self.factory.post(
             "/upload_file/",
-            {
-                "course_choice": "new",
-                "new_course": "Test Course",
-                "model": "Test Model",
-            },
+            post_data,
         )
-        uploaded_file = SimpleUploadedFile("test.txt", file_content)
+        uploaded_file = SimpleUploadedFile(file_name, file_content)
         request.FILES["file"] = uploaded_file
 
         request.user = self.user
@@ -140,6 +146,65 @@ class UploadFileTestCase(TestCase):
         """This test case checks the behavior when an empty exam file is uploaded.
         It should return a 400 status code and not create any exam or questions."""
         self.__test_updload_file_invalid_exam_file("")
+
+    def test_upload_blocks_duplicate_exam_name_from_file_name(self):
+        """Uploading with an existing exam name in the same course returns 409 and avoids duplicates."""
+        existing_exam = Exam.objects.create(description="test.txt", course=self.course, user=self.user)
+
+        request = self._mock_request(file_content=VALID_EXAM_FILE_CONTENT.encode(), file_name="test.txt")
+        response = upload_file(request)
+
+        self.assertEqual(response.status_code, 409)
+        payload = json.loads(response.content)
+        self.assertEqual(payload["error"], "duplicate_exam")
+        self.assertEqual(payload["existing_exam_id"], existing_exam.id)
+        self.assertEqual(payload["exam_name"], "test.txt")
+        self.assertEqual(payload["course_name"], self.course.name)
+        self.assertEqual(payload["message"], "An exam with this name already exists in this course.")
+        self.assertEqual(Exam.objects.count(), 1)
+        self.assertEqual(Question.objects.count(), 0)
+
+    def test_upload_blocks_duplicate_exam_name_from_user_exam(self):
+        """The user_exam field has priority over file name when checking for conflicts."""
+        existing_exam = Exam.objects.create(description="Midterm 1", course=self.course, user=self.user)
+
+        request = self._mock_request(
+            file_content=VALID_EXAM_FILE_CONTENT.encode(),
+            file_name="another_file.txt",
+            user_exam="Midterm 1",
+        )
+        response = upload_file(request)
+
+        self.assertEqual(response.status_code, 409)
+        payload = json.loads(response.content)
+        self.assertEqual(payload["error"], "duplicate_exam")
+        self.assertEqual(payload["existing_exam_id"], existing_exam.id)
+        self.assertEqual(payload["exam_name"], "Midterm 1")
+        self.assertEqual(payload["course_name"], self.course.name)
+        self.assertEqual(payload["message"], "An exam with this name already exists in this course.")
+        self.assertEqual(Exam.objects.count(), 1)
+        self.assertEqual(Question.objects.count(), 0)
+
+    def test_upload_allows_same_exam_name_in_different_course(self):
+        """Exam names are unique per course, so same name in another course is allowed."""
+        other_course = Course.objects.create(name="Other Course", user=self.user)
+        Exam.objects.create(description="test.txt", course=self.course, user=self.user)
+
+        request = self.factory.post(
+            "/upload_file/",
+            {
+                "course_choice": "existing",
+                "course_id": str(other_course.id),
+                "model": "Test Model",
+            },
+        )
+        request.FILES["file"] = SimpleUploadedFile("test.txt", VALID_EXAM_FILE_CONTENT.encode())
+        request.user = self.user
+
+        response = upload_file(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Exam.objects.filter(description="test.txt").count(), 2)
 
 class TestExamService(TestCase):
     def test_invalid_exam_file_no_options(self):

--- a/mi_web/urls.py
+++ b/mi_web/urls.py
@@ -37,6 +37,8 @@ urlpatterns = [
  
     path('evaluate/', evaluate_view, name='evaluate'),
     path('course/', course_view, name='course'),
+
+    #This is the URL that the frontend will call to upload the exam file. It is handled by the upload_file view which processes the file and creates the necessary database entries.
     path('upload/', upload_file, name='upload_file'),
     path('exam/<int:exam_id>/', exam_detail, name='exam_detail'),
     path('analysis/', analysis_view, name='analysis'),

--- a/static/css/evaluate.css
+++ b/static/css/evaluate.css
@@ -1,14 +1,14 @@
-/* exam.css - Tema Oscuro Azul */
+/* Tema Oscuro Azul */
 :root {
-  --primary-color: #3b82f6;       /* Azul brillante principal */
-  --secondary-color: #1e3a8a;     /* Azul oscuro para contrastes */
-  --success-color: #22c55e;       /* Verde para éxito */
-  --error-color: #ef4444;         /* Rojo para errores */
-  --background-dark: #0f172a;     /* Fondo oscuro principal */
-  --background-medium: #1e293b;   /* Fondo intermedio */
-  --text-color: #f8fafc;          /* Texto principal claro */
-  --text-light: #94a3b8;          /* Texto secundario */
-  --border-color: #334155;        /* Color de bordes */
+  --primary-color: #3b82f6;
+  --secondary-color: #1e3a8a;
+  --success-color: #22c55e;
+  --error-color: #ef4444;
+  --background-dark: #0f172a;
+  --background-medium: #1e293b;
+  --text-color: #f8fafc;
+  --text-light: #94a3b8;
+  --border-color: #334155;
 }
 
 body {
@@ -33,7 +33,7 @@ h2 {
   padding: 2rem;
   background: var(--background-medium);
   border-radius: 12px;
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   border: 1px solid var(--border-color);
 }
 
@@ -50,7 +50,6 @@ h2 {
   padding: 1rem;
   background: var(--background-dark);
   border-radius: 8px;
-  transition: all 0.2s ease;
   border: 1px solid var(--border-color);
 }
 
@@ -72,7 +71,6 @@ select, input[type="text"], input[type="file"] {
   border: 2px solid var(--border-color);
   border-radius: 8px;
   font-size: 1rem;
-  transition: var(--transition);
   background: var(--background-dark);
   color: var(--text-color);
 }
@@ -106,7 +104,6 @@ input[type="file"]::file-selector-button {
   border: none;
   border-radius: 6px;
   cursor: pointer;
-  transition: var(--transition);
 }
 
 input[type="file"]::file-selector-button:hover {
@@ -118,14 +115,12 @@ input[type="file"]::file-selector-button:hover {
   padding: 1rem;
   background: var(--primary-color);
   color: var(--text-color);
-  border: none;
   border-radius: 8px;
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
-  transition: var(--transition);
   margin: 1.5rem 0;
-  border: 2px solid transparent;
+  border: none;
 }
 
 #exam-form button[type="submit"]:hover {
@@ -140,7 +135,7 @@ input[type="file"]::file-selector-button:hover {
   padding: 2rem;
   background: var(--background-medium);
   border-radius: 12px;
-  box-shadow: var(--shadow-md);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   border: 1px solid var(--border-color);
 }
 
@@ -160,19 +155,15 @@ input[type="file"]::file-selector-button:hover {
 
 #progress-bar {
   height: 1rem;
-  transition: width 0.5s ease;
 }
 
 #exam-results {
-  max-width: 800px;
+  max-width: 860px;
   margin: 2rem auto;
-  padding: 2rem;
-  background: var(--background-medium);
-  border-radius: 12px;
-  box-shadow: var(--shadow-md);
-  font-weight: 500;
-  text-align: center;
-  border: 1px solid var(--border-color);
+  padding: 0;
+  background: transparent;
+  border: none;
+  text-align: left;
 }
 
 #exam-details {
@@ -180,12 +171,103 @@ input[type="file"]::file-selector-button:hover {
   margin: 2rem auto;
 }
 
+.is-hidden {
+  display: none;
+}
+
+#user-exam.is-invalid {
+  border-color: var(--error-color);
+  background-color: #2a1116;
+  color: #fee2e2;
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.28);
+}
+
+#user-exam.is-invalid:focus {
+  border-color: var(--error-color);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.35);
+}
+
+#user-exam.is-invalid-highlight {
+  animation: examInputErrorPulse 0.85s ease-in-out 2;
+}
+
+@keyframes examInputErrorPulse {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.45);
+  }
+  50% {
+    transform: scale(1.01);
+    box-shadow: 0 0 0 6px rgba(239, 68, 68, 0.18);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0);
+  }
+}
+
+.field-error {
+  display: none;
+  margin: 0.5rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(239, 68, 68, 0.5);
+  border-radius: 8px;
+  background: rgba(127, 29, 29, 0.2);
+  color: #fca5a5;
+  font-size: 0.92rem;
+}
+
+.field-error.is-visible {
+  display: block;
+}
+
+.field-error-title {
+  margin: 0;
+  color: #fecaca;
+  font-weight: 600;
+}
+
+.field-error-context {
+  margin: 0.5rem 0 0;
+  color: #fca5a5;
+}
+
+.field-error-list {
+  margin: 0.6rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.field-error-list li {
+  margin: 0.35rem 0;
+}
+
+.field-error-links {
+  display: flex;
+  gap: 0.9rem;
+  margin-top: 0.7rem;
+}
+
+.field-error-links a {
+  color: #93c5fd;
+  text-decoration: underline;
+}
+
+.field-error-links a:hover {
+  color: #bfdbfe;
+}
+
+.error-message {
+  color: #fca5a5;
+  text-align: center;
+  margin-top: 1.25rem;
+}
+
 #exam-details > div {
   margin: 1.5rem 0;
   padding: 1.5rem;
   background: var(--background-medium);
   border-radius: 12px;
-  box-shadow: var(--shadow-sm);
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   border: 1px solid var(--border-color);
 }
 
@@ -201,14 +283,186 @@ pre {
   border: 1px solid var(--border-color);
 }
 
-@media (max-width: 768px) {
-  #exam-form, #loading-indicator, #exam-results, #exam-details {
-      margin: 1rem;
-      padding: 1rem;
-  }
-  
-  #course-selection > div {
-      flex-direction: column;
-      align-items: flex-start;
-  }
+/* UPLOAD WARNING - DESKTOP ONLY */
+.upload-warning-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem 0;
+  animation: fadeIn 0.3s ease-in-out;
 }
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.warning-card {
+  background-color: var(--background-medium);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  padding: 32px;
+  max-width: 550px;
+  width: 100%;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+}
+
+.warning-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.warning-header .icon {
+  font-size: 28px;
+  flex-shrink: 0;
+}
+
+.warning-header h2 {
+  color: #f59e0b;
+  margin: 0;
+  font-size: 24px;
+  text-align: left;
+  text-shadow: none;
+}
+
+.main-message {
+  font-size: 16px;
+  line-height: 1.5;
+  margin-bottom: 24px;
+  color: var(--text-color);
+}
+
+.details-box {
+  background-color: var(--background-dark);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  padding: 16px;
+  margin-bottom: 24px;
+}
+
+.detail-row {
+  display: flex;
+  margin-bottom: 8px;
+}
+
+.detail-row:last-child {
+  margin-bottom: 0;
+}
+
+.detail-label {
+  width: 100px;
+  color: var(--text-light);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.detail-value {
+  color: #60a5fa;
+  font-family: monospace;
+  font-size: 15px;
+  word-break: break-all;
+  margin-left: 1rem;
+}
+
+.action-info h3 {
+  font-size: 14px;
+  text-transform: uppercase;
+  color: var(--text-light);
+  letter-spacing: 0.5px;
+  margin: 0 0 12px 0;
+}
+
+.action-info ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 32px 0;
+}
+
+.action-info li {
+  background: rgba(255, 255, 255, 0.03);
+  border-left: 3px solid var(--primary-color);
+  padding: 12px 16px;
+  margin-bottom: 8px;
+  border-radius: 0 6px 6px 0;
+  font-size: 15px;
+}
+
+.button-group {
+  display: flex;
+  gap: 16px;
+}
+
+.button-group a {
+  text-decoration: none;
+  padding: 12px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 15px;
+  text-align: center;
+  flex: 1;
+  min-width: 200px;
+}
+
+.btn-primary {
+  background-color: var(--primary-color);
+  color: white !important;
+  border: 1px solid var(--primary-color);
+}
+
+.btn-primary:hover {
+  background-color: var(--secondary-color);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.btn-secondary {
+  background-color: transparent;
+  color: var(--text-color) !important;
+  border: 1px solid var(--border-color);
+}
+
+.btn-secondary:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+  border-color: var(--text-light);
+}
+
+.instructions-box {
+  background-color: rgba(96, 165, 250, 0.1);
+  border: 1px solid rgba(96, 165, 250, 0.3);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.instructions-box h3 {
+  color: #60a5fa;
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin: 0 0 16px 0;
+  font-weight: 600;
+}
+
+.instruction-item {
+  margin-bottom: 16px;
+}
+
+.instruction-item:last-child {
+  margin-bottom: 0;
+}
+
+.instruction-item h4 {
+  color: var(--text-color);
+  margin: 0 0 8px 0;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.instruction-item p {
+  color: var(--text-light);
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+}
+

--- a/static/js/evaluate.js
+++ b/static/js/evaluate.js
@@ -1,29 +1,76 @@
 $(document).ready(function () {
+  const examNameInput = $("#user-exam");
+  const examNameError = $("#user-exam-error");
+
+  function escapeHtml(text) {
+    return $("<div>").text(text || "").html();
+  }
+
+  function showExamNameError(content, isHtml = false) {
+    examNameInput.addClass("is-invalid").attr("aria-invalid", "true");
+    examNameInput.removeClass("is-invalid-highlight");
+    if (isHtml) {
+      examNameError.html(content);
+    } else {
+      examNameError.text(content);
+    }
+    examNameError.addClass("is-visible");
+    const inputElement = examNameInput.get(0);
+    if (inputElement) {
+      inputElement.scrollIntoView({ behavior: "smooth", block: "center" });
+      inputElement.focus();
+      examNameInput.addClass("is-invalid-highlight");
+    }
+  }
+
+  function clearExamNameError() {
+    examNameInput.removeClass("is-invalid is-invalid-highlight").removeAttr("aria-invalid");
+    examNameError.text("").removeClass("is-visible");
+  }
+
   function toggleCourseInputs() {
     const courseChoice = $('input[name="course_choice"]:checked').val();
-    if (courseChoice === 'new') {
-      $('#course-select').hide();
-      $('#new-course-input').show().prop('required', true);
+    if (courseChoice === "new") {
+      $("#course-select").hide();
+      $("#new-course-input").show().prop("required", true);
     } else {
-      $('#course-select').show();
-      $('#new-course-input').hide().prop('required', false);
+      $("#course-select").show();
+      $("#new-course-input").hide().prop("required", false);
     }
   }
 
   toggleCourseInputs();
   $('input[name="course_choice"]').change(toggleCourseInputs);
 
+  examNameInput.on("input", clearExamNameError);
+
+  function buildDuplicateExamMessage(payload) {
+    const examName = escapeHtml(payload.exam_name || "Unknown");
+    const courseName = escapeHtml(payload.course_name || "Unknown");
+
+    return `
+      <p class="field-error-title">${escapeHtml(payload.message || "An exam with this name already exists in this course.")}</p>
+      <ul class="field-error-list">
+        <li><strong>If it is a different exam:</strong> Rename the uploaded file or change the <strong>Exam name</strong> field.</li>
+        <li><strong>If it is the same exam:</strong> Do not re-upload. Open the existing exam or use Batch Evaluation to compare models.</li>
+      </ul>
+    `;
+  }
+
   $("#exam-form").submit(function (event) {
     event.preventDefault();
 
     const courseChoice = $('input[name="course_choice"]:checked').val();
-    if (courseChoice === 'new' && !$('#new-course-input').val().trim()) {
-      alert('Please enter the name of the new course');
+    if (courseChoice === "new" && !$("#new-course-input").val().trim()) {
+      alert("Please enter the name of the new course");
       return;
     }
 
+    clearExamNameError();
     resetUI();
     const formData = new FormData(this);
+
+    let duplicateConflictHandled = false;
 
     fetch("/upload/", {
       method: "POST",
@@ -32,14 +79,29 @@ $(document).ready(function () {
     })
       .then((response) => {
         if (!response.ok) {
+          if (response.status === 409) {
+            return response.json().then((payload) => {
+              $("#loading-indicator").hide();
+              if (payload && payload.error === "duplicate_exam") {
+                showExamNameError(buildDuplicateExamMessage(payload), true);
+                duplicateConflictHandled = true;
+                throw new Error(payload.message || "An exam with this name already exists in this course.");
+              }
+              throw new Error("A conflict was detected while uploading the exam.");
+            });
+          }
           return handleErrorResponse(response, "There was an error processing the file.");
         }
         return handleStreamingResponse(response, updateUI);
       })
       .catch((error) => {
+        if (duplicateConflictHandled) {
+          return;
+        }
         console.error("Error:", error);
         $("#loading-indicator").hide();
-        $("#exam-results").html("Error processing the file.");
+        const errorMessage = error.message ? error.message : "Error processing the file.";
+        $("#exam-results").html(`<div class="error-message">${errorMessage}</div>`);
       });
   });
 });


### PR DESCRIPTION
## 🎯 Summary

This PR introduces a validation mechanism to prevent users from uploading and evaluating the exact same exam with the same LLM model within a specific course. It also includes the corresponding frontend error handling to display a clear and user-friendly notification when a duplicate upload is attempted.

## 🔄 Changes in the repository

**`feat`**: The system now prevents duplicate exam evaluations with the same model.

## 🔗 Related issues

Closes #3 , Closes #2

## 🛠️ Implementation details

Backend (upload_file_service.py): Added the is_unique_exam database validation to prevent exam duplication. If the exam already exists in the course and has been evaluated by the requested model, the endpoint now intercepts the upload and returns an HTTP 409 Conflict status code along with an explanatory message.

Frontend (static/js/evaluate.js): Updated the fetch promise chain to properly handle 409 Conflict statuses. It now resolves the promise with the backend's error text and displays it directly in the UI instead of failing silently or showing a generic error.
